### PR TITLE
Derive `Clone` for RequestContext

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -77,6 +77,7 @@ async fn convert_response(res: reqwest::Response) -> Result<http::Response<bytes
     Ok(builder.body(buffer.freeze())?)
 }
 
+#[derive(Clone)]
 pub struct RequestContext {
     pub client: reqwest::Client,
     pub auth: Arc<oauth::TokenProviderWrapper>,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

I added a `#[derive(Clone)]` for the `RequestContext` struct. Its members already derive clone because the `reqwest` Client derives clone (and its only member is of type `Arc<T>`) and the `auth` field of `RequestContext` is of type `Arc<T>`, which, of course, impls `Clone`. This derive makes it easier to use `RequestContext` for shared state so that you don't need an additional `Arc` to wrap it in order for it to impl `Clone`.

### Related Issues

N/A (I wasn't sure whether it was required for me to create an issue for this since this is a relatively simple PR and doesn't introduce any breaking changes. Please let me know if I do need one; I'd be happy to create it and reference it in this PR)
