### PR TITLE
cli: omit ANSI colors when not a TTY or `NO_COLOR` is set

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,124 @@
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+    io::IsTerminal,
+};
+
+use nu_ansi_term::{AnsiGenericString, Color, Style};
+
+/// Environment variables that determine whether ANSI colors should be used.
+///
+/// Color is used if the output stream [is a terminal][IsTerminal] and the
+/// [`NO_COLOR`](https://no-color.org) environment variable is unset or empty.
+#[derive(Debug, Copy, Clone)]
+pub struct ColorCtx {
+    no_color: bool,
+    stdout_isatty: bool,
+    stderr_isatty: bool,
+}
+
+/// Result of [`ColorCtx::paint`], which is a [`nu_ansi_term::AnsiGenericString`] if color should
+/// be used or a plain string otherwise.
+#[derive(PartialEq, Debug, Clone)]
+pub enum Painting<'a, S: ToOwned + ?Sized>
+where
+    <S as ToOwned>::Owned: Debug,
+{
+    Plain(Cow<'a, S>),
+    Styled(AnsiGenericString<'a, S>),
+}
+
+impl<'a, S: 'a + ToOwned + ?Sized> Display for Painting<'a, S>
+where
+    <S as ToOwned>::Owned: Debug,
+    Cow<'a, S>: Display,
+    AnsiGenericString<'a, S>: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Painting::Plain(inner) => inner.fmt(f),
+            Painting::Styled(inner) => inner.fmt(f),
+        }
+    }
+}
+
+impl ColorCtx {
+    /// Reads the environment into a `ColorCtx`.
+    ///
+    /// You can call this once at the start of your program.
+    pub fn from_env() -> Self {
+        Self {
+            no_color: std::env::var_os("NO_COLOR").is_some_and(|x| !x.is_empty()),
+            stdout_isatty: std::io::stdout().is_terminal(),
+            stderr_isatty: std::io::stderr().is_terminal(),
+        }
+    }
+
+    /// Paints a string destined for stdout.
+    ///
+    /// Analogous to `p.paint(input)`, but produces a plain string if color should not be used for
+    /// stdout.
+    pub fn paint<'a, P: Paint, I, S: 'a + ToOwned + ?Sized>(
+        &self,
+        p: P,
+        input: I,
+    ) -> Painting<'a, S>
+    where
+        I: Into<Cow<'a, S>>,
+        <S as ToOwned>::Owned: Debug,
+    {
+        if self.no_color || !self.stdout_isatty {
+            Painting::Plain(input.into())
+        } else {
+            Painting::Styled(p.paint(input))
+        }
+    }
+
+    /// Paints a string destined for stderr.
+    ///
+    /// Analogous to `p.paint(input)`, but produces a plain string if color should not be used for
+    /// stderr.
+    pub fn paint_err<'a, P: Paint, I, S: 'a + ToOwned + ?Sized>(
+        &self,
+        p: P,
+        input: I,
+    ) -> Painting<'a, S>
+    where
+        I: Into<Cow<'a, S>>,
+        <S as ToOwned>::Owned: Debug,
+    {
+        if self.no_color || !self.stderr_isatty {
+            Painting::Plain(input.into())
+        } else {
+            Painting::Styled(p.paint(input))
+        }
+    }
+}
+
+/// Common supertype for `nu_ansi_term` methods [`Style::paint`] and [`Color::paint`].
+pub trait Paint {
+    fn paint<'a, I, S: 'a + ToOwned + ?Sized>(self, input: I) -> AnsiGenericString<'a, S>
+    where
+        I: Into<Cow<'a, S>>,
+        <S as ToOwned>::Owned: Debug;
+}
+
+impl Paint for Style {
+    fn paint<'a, I, S: 'a + ToOwned + ?Sized>(self, input: I) -> AnsiGenericString<'a, S>
+    where
+        I: Into<Cow<'a, S>>,
+        <S as ToOwned>::Owned: Debug,
+    {
+        self.paint(input)
+    }
+}
+
+impl Paint for Color {
+    fn paint<'a, I, S: 'a + ToOwned + ?Sized>(self, input: I) -> AnsiGenericString<'a, S>
+    where
+        I: Into<Cow<'a, S>>,
+        <S as ToOwned>::Owned: Debug,
+    {
+        self.paint(input)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod cat;
+pub mod color;
 pub mod cp;
 pub mod ls;
 pub mod rm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,10 +80,14 @@ async fn real_main() -> anyhow::Result<()> {
 
 #[tokio::main]
 async fn main() {
+    let cc = gsutil::color::ColorCtx::from_env();
     match real_main().await {
         Ok(_) => {}
         Err(e) => {
-            eprintln!("{}", nu_ansi_term::Color::Red.paint(format!("{e:?}")));
+            eprintln!(
+                "{}",
+                cc.paint_err(nu_ansi_term::Color::Red, format!("{e:?}"))
+            );
             #[allow(clippy::exit)]
             std::process::exit(1);
         }

--- a/src/setmeta.rs
+++ b/src/setmeta.rs
@@ -1,4 +1,4 @@
-use crate::util;
+use crate::{color::ColorCtx, util};
 use anyhow::Context as _;
 
 #[derive(clap::Parser, Debug)]
@@ -10,6 +10,8 @@ pub struct Args {
 }
 
 pub async fn cmd(ctx: &util::RequestContext, args: Args) -> anyhow::Result<()> {
+    let cc = ColorCtx::from_env();
+
     let oid = util::gs_url_to_object_id(&args.url)?;
 
     let md: tame_gcs::objects::Metadata = serde_json::from_str(&args.json)?;
@@ -28,7 +30,7 @@ pub async fn cmd(ctx: &util::RequestContext, args: Args) -> anyhow::Result<()> {
     let md = get_res.metadata;
 
     // Print out the information the same way gsutil does, except with RFC-2822 date formatting
-    println!("{}", nu_ansi_term::Color::Cyan.paint(args.url.as_str()));
+    println!("{}", cc.paint(nu_ansi_term::Color::Cyan, args.url.as_str()));
     println!(
         "    Creation time:\t{}",
         md.time_created

--- a/src/stat.rs
+++ b/src/stat.rs
@@ -1,4 +1,4 @@
-use crate::util;
+use crate::{color::ColorCtx, util};
 use anyhow::Context as _;
 
 #[derive(clap::Parser, Debug)]
@@ -9,6 +9,7 @@ pub struct Args {
 
 pub async fn cmd(ctx: &util::RequestContext, args: Args) -> anyhow::Result<()> {
     let oid = util::gs_url_to_object_id(&args.url)?;
+    let cc = ColorCtx::from_env();
 
     let get_req = ctx.obj.get(
         &(
@@ -22,7 +23,7 @@ pub async fn cmd(ctx: &util::RequestContext, args: Args) -> anyhow::Result<()> {
     let md = get_res.metadata;
 
     // Print out the information the same way gsutil does, except with RFC-2822 date formatting
-    println!("{}", nu_ansi_term::Color::Cyan.paint(args.url.as_str()));
+    println!("{}", cc.paint(nu_ansi_term::Color::Cyan, args.url.as_str()));
     println!(
         "    Creation time:\t{}",
         md.time_created


### PR DESCRIPTION
* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

The colors used by `gsutil` are unreadable on my light-background color
scheme, and `gsutil` does not respect either the [`NO_COLOR`] env var or
being piped to a non-TTY stream. This patch makes it respect both.

I looked for all matches of `git grep -P '(?<!cc)\.paint'`, which
previously matched `ls`, `main`, `setmeta`, and `stat`, and now only
matches the internals of the new `color` module. If there are other ways
that ANSI codes are emitted, I may have missed them.

Addresses #11. Arguably fixes it via the environment variable; an
explicit command line option `--no-color` could still be added, which
this patch makes easy.

This uses the recently-stabilized [`IsTerminal`] trait, which bumps the
MSRV to 1.70.0.

[`IsTerminal`]: https://doc.rust-lang.org/std/io/trait.IsTerminal.html
[`NO_COLOR`]: https://no-color.org

wchargin-branch: no-color

