### PR TITLE
util: fix crash on bare `gs://bucket` with no path

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -159,7 +159,11 @@ pub fn gs_url_to_object_id(url: &url::Url) -> anyhow::Result<GsUrl> {
         "gs" => {
             let bucket_name = url.host_str().context("no bucket specified")?;
             // Skip first /
-            let object_name = &url.path()[1..];
+            let object_name = if url.path().is_empty() {
+                ""
+            } else {
+                &url.path()[1..]
+            };
 
             Ok(GsUrl {
                 bucket_name: tame_gcs::BucketName::try_from(String::from(bucket_name))?,


### PR DESCRIPTION
* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

Running `gsutil ls gs://some-bucket-name` with no trailing slash used to
crash with:

    thread 'main' panicked at 'byte index 1 is out of bounds of ``', src/util.rs:162:32

It now behaves the same as upstream `gsutil`: that is, it is equivalent
to the same URL if its path part were a single slash.

Fixes #12.

wchargin-branch: fix-bare-bucket
